### PR TITLE
Make changing `AddressSRAM` in `Mods.asm` also change this automatically

### DIFF
--- a/sonic.asm
+++ b/sonic.asm
@@ -353,7 +353,12 @@ GameInit:
 	if SaveProgressMod=1
 InitSRAM:
 		move.b  #1,(sram_port).l	; Enable SRAM writing
-		lea 	($200001).l,a0		; Load SRAM memory into a0 (Change the last digit to 0 if you're using even SRAM)
+	if AddressSRAM=3
+		; no need to change this by yourself anymore.
+		lea 	($200001).l,a0		; Load SRAM memory into a0
+	else
+		lea	($200000).l,a0		; Load SRAM memory into a0
+	endif
 		movep.l 0(a0),d0			; Get the existing string at the start of SRAM
 		move.l  #"SRAM",d1			; Write the string "SRAM" to d1
 		cmp.l   d0,d1				; Was it already in SRAM?


### PR DESCRIPTION
1) I'm not aware of any other places this needs to be changed. are there any? if so, I'll make this modification there too.
2) should odd+even use $200001 instead?