### PR TITLE
temporary bandaid fix for $5D and $5F sound crashes

### DIFF
--- a/_inc/Level Select (S2).asm
+++ b/_inc/Level Select (S2).asm
@@ -254,6 +254,13 @@ LevSelControls_CheckLR:
 		andi.w	#btnBC,d1
 		beq.s	.rts	; rts
 		move.w	(v_levselsound).w,d0
+		; temp. bandaid fix for crashes when playing these sounds in particular.
+        	cmpi.w  #$5D,d0
+        	beq.s   .rts
+        	cmpi.w  #$5F,d0
+      		beq.s   .rts
+		addi.w	#$80,d0
+		bra.w	PlaySound
 		addi.w	#$80,d0
 		bra.w	PlaySound
 		;lea	(debug_cheat).l,a0


### PR DESCRIPTION
(note: if preventing the play of these sounds in particular to prevent crashes is not a viable/desired case, don't merge this PR!)
to be refined after merging to not use magic number IDs in case someone populates sound $5D/$5F so it doesn't cause a crash.

https://github.com/RetroKoH/S1Fixed/issues/47