### PR TITLE
Fix bugs with certain mods being disabled

### DIFF
--- a/Mods.asm
+++ b/Mods.asm
@@ -107,6 +107,11 @@ OrbinautAnimationTweak: = 1
 ; Function: Makes the SLZ Orbinauts beatable by giving them behaviour similar to Sonic 4's.
 SLZOrbinautBehaviourMod: = 1
 
+; Name: Signpost Control Lock Bypass Fix
+; Credit: Fix by Clownacy, reintroduced as mod by Amy Farbright
+; Function: Fixes an edge case where being offscreen and in the air as the score tally starts avoids locking controls to run forward
+SignpostControlLockFix: = 1
+
 ; Name: Speed Up/Instant Score Tally
 ; Credit: Mercury/RetroKoH
 ; Function: Allows the player to hold a button to speed up the score tally, or just have it occur immediately

--- a/_incObj/0D Signpost.asm
+++ b/_incObj/0D Signpost.asm
@@ -189,6 +189,7 @@ Sign_SparkPos:
 Sign_SonicRun:	; Routine 6
 		tst.w	(v_debuguse).w	; is debug mode	on?
 		bne.s	ret_EC86	; if yes, branch
+	if SignpostControlLockFix=1
 	; Signpost Routine Fix
 	; This function's checks are a mess, creating an edgecase where it's
 	; possible for the player to avoid having their controls locked by
@@ -202,6 +203,15 @@ Sign_SonicRun:	; Routine 6
 		move.b	#1,(f_lockctrl).w			; lock controls
 		move.w	#btnR<<8,(v_jpadhold2).w	; make Sonic run to the right
 	; Old check moved to above -- Signpost Routine Fix
+	else
+		btst	#staAir,(v_player+obStatus).w
+		bne.s	.skiplockcontrols
+		move.b	#1,(f_lockctrl).w			; lock controls
+		move.w	#btnR<<8,(v_jpadhold2).w	; make Sonic run to the right
+.skiplockcontrols:
+		tst.b	(v_player+obID).w			; Check if Sonic's object has been deleted (because he entered the giant ring)
+		beq.s	loc_EC86
+	endif
 		move.w	(v_player+obX).w,d0
 		move.w	(v_limitright2).w,d1
 		addi.w	#$128,d1

--- a/_incObj/8D Super Sonic Stars.asm
+++ b/_incObj/8D Super Sonic Stars.asm
@@ -4,6 +4,7 @@
 ; ---------------------------------------------------------------------------
 
 SuperStars:
+	if SuperMod=1
 	; LavaGaming Object Routine Optimization
 		tst.b	obRoutine(a0)
 		bne.s	SStars_Next
@@ -76,5 +77,6 @@ loc_1E1AA:
 ; ===========================================================================
 
 SStars_Delete:
+	endif
 		jmp		(DeleteObject).l
 ; ===========================================================================

--- a/s1.sounddriver.asm
+++ b/s1.sounddriver.asm
@@ -182,6 +182,7 @@ UpdateMusic:
 		jsr	PlaySoundID(pc)
 ; loc_71BC8:
 .nonewsound:
+	if SpinDashEnabled=1
 	; Spin Dash SFX
 		tst.b	(v_spindashsfx2).w
 		beq.s	.cont
@@ -189,6 +190,7 @@ UpdateMusic:
 
 .cont:
 	; Spin Dash SFX end
+	endif
 		lea		SMPS_RAM.v_music_dac_track(a6),a5
 		tst.b	SMPS_Track.PlaybackControl(a5)	; Is DAC track playing?
 		bpl.s	.dacdone					; Branch if not
@@ -992,6 +994,7 @@ Sound_SpecialSFX:
 		bne.w	Sound_ClearPriority
 		tst.b	SMPS_RAM.f_fadein_flag(a6)
 		bne.w	Sound_ClearPriority
+	if SpinDashEnabled=1
 		clr.b	(v_spindashsfx1).w
 		cmp.b	#sfx_SpinDash,d7		; is this the Spin Dash sound?
 		bne.s	.cont3	; if not, branch
@@ -1013,6 +1016,7 @@ Sound_SpecialSFX:
 		move.w	(sp)+,d0
 
 .cont3:
+	endif
 		movea.l	Go_SoundIndex(pc),a0
 		sub.b	#$A0,d7
 		bra.w	SoundEffects_Common
@@ -1027,7 +1031,9 @@ Sound_PlaySFX:
 		bne.w	Sound_ClearPriority		; Exit if it is
 		tst.b	SMPS_RAM.f_fadein_flag(a6)		; Is music being faded in?
 		bne.w	Sound_ClearPriority		; Exit if it is
+	if SpinDashEnabled=1
 		clr.b	(v_spindashsfx1).w		; Spin Dash SFX
+	endif
 		cmpi.b	#sfx_Ring,d7			; is ring sound	effect played?
 		bne.s	.sfx_notRing			; if not, branch
 		tst.b	SMPS_RAM.v_ring_speaker(a6)		; Is the ring sound playing on right speaker?
@@ -1045,6 +1051,7 @@ Sound_PlaySFX:
 		move.b	#$80,SMPS_RAM.f_push_playing(a6)	; Mark it as playing
 ; Sound_notA7:
 .sfx_notPush:
+	if SpinDashEnabled=1
 	; Spin Dash SFX
 		cmp.b	#sfx_SpinDash,d7		; is this the Spin Dash sound?
 		bne.s	.cont3					; if not, branch
@@ -1067,6 +1074,7 @@ Sound_PlaySFX:
 
 .cont3:
 	; Spin Dash SFX End
+	endif
 		movea.l	(Go_SoundIndex).l,a0
 		subi.b	#sfx__First,d7		; Make it 0-based
 
@@ -1126,6 +1134,7 @@ SoundEffects_Common:
 		add.l	a3,d0				; Relative pointer
 		move.l	d0,SMPS_Track.DataPointer(a5)	; Store track pointer
 		move.w	(a1)+,SMPS_Track.Transpose(a5)	; load FM/PSG channel modifier
+	if SpinDashEnabled=1
 	; Spin Dash SFX
 		tst.b	(v_spindashsfx1).w	; is the Spin Dash sound playing?
 		beq.s	.cont		; if not, branch
@@ -1136,6 +1145,7 @@ SoundEffects_Common:
 
 	.cont:
 	; Spin Dash SFX End
+	endif
 		move.b	#1,SMPS_Track.DurationTimeout(a5)	; Set duration of first "note"
 		move.b	d6,SMPS_Track.StackPointer(a5)	; set "gosub" (coord flag $F8) stack init value
 		tst.b	d4				; Is this a PSG channel?

--- a/sonic.asm
+++ b/sonic.asm
@@ -7318,10 +7318,10 @@ Eni_Title:	binclude	"tilemaps/Title Screen.eni" ; title screen foreground (mappi
 
 	if SaveProgressMod=1
 Nem_TitleFg:	binclude	"artnem/Title Screen Foreground (Menu).nem"
-		even
 	else
 Nem_TitleFg:	binclude	"artnem/Title Screen Foreground.nem"
 	endif
+		even
 
 
 Nem_TitleTM:	binclude	"artnem/Title Screen TM.nem"


### PR DESCRIPTION
This PR holds a few fixes that allow the game to be built and avoid crashes when certain mods are disabled:
- Disabling spindash also excludes related variables from RAM. The sound driver references these variables without checking if the spindash mod is enabled or not. I've added checks around these references so they are excluded alongside the spindash proper.
- The Super Sonic star object references data that's excluded from assembly when Super forms are enabled. I chose to replace the entire star object with a jump to `DeleteObject` if Super forms are disabled in the build.
- If SRAM is disabled, the inclusion of `Nem_TitleFg` omits an even directive, causing `Nem_TitleTM` to fall on an odd address and invoking an address error as the title screen is loading.

Additionally, I've added my own small mod, that makes the signpost control lock fix ("`Signpost Routine Fix`") optional, similar to the spike bug. It's turned on by default to match this disassembly's existing behavior.