### PR TITLE
Fixed Buzz Bomber's Wings

### DIFF
--- a/_maps/Buzz Bomber.asm
+++ b/_maps/Buzz Bomber.asm
@@ -9,60 +9,60 @@ Map_Buzz:	mappingsTable
 	mappingsTableEntry.w	.Fire1
 	mappingsTableEntry.w	.Fire2
 
-.Fly1:	spriteHeader
-	spritePiece	-$18, -$C, 3, 2, 0, 0, 0, 0, 0	; flying
-	spritePiece	0, -$C, 3, 2, $F, 0, 0, 0, 0
-	spritePiece	-$18, 4, 3, 1, $15, 0, 0, 0, 0
-	spritePiece	0, 4, 2, 1, $18, 0, 0, 0, 0
-	spritePiece	-$14, -$F, 3, 1, $1A, 0, 0, 0, 0
-	spritePiece	4, -$F, 2, 1, $1D, 0, 0, 0, 0
-.Fly1_End
-
-.Fly2:	spriteHeader
+.Fly1:	spriteHeader	; flying
+	spritePiece	-$18, -$F, 3, 1, $1A, 0, 0, 0, 0
+	spritePiece	0, -$F, 2, 1, $1D, 0, 0, 0, 0
 	spritePiece	-$18, -$C, 3, 2, 0, 0, 0, 0, 0
 	spritePiece	0, -$C, 3, 2, $F, 0, 0, 0, 0
 	spritePiece	-$18, 4, 3, 1, $15, 0, 0, 0, 0
 	spritePiece	0, 4, 2, 1, $18, 0, 0, 0, 0
-	spritePiece	-$14, -$C, 3, 1, $1F, 0, 0, 0, 0
-	spritePiece	4, -$C, 2, 1, $22, 0, 0, 0, 0
+.Fly1_End
+
+.Fly2:	spriteHeader
+	spritePiece	-$18, -$C, 3, 1, $1F, 0, 0, 0, 0
+	spritePiece	0, -$C, 2, 1, $22, 0, 0, 0, 0
+	spritePiece	-$18, -$C, 3, 2, 0, 0, 0, 0, 0
+	spritePiece	0, -$C, 3, 2, $F, 0, 0, 0, 0
+	spritePiece	-$18, 4, 3, 1, $15, 0, 0, 0, 0
+	spritePiece	0, 4, 2, 1, $18, 0, 0, 0, 0
 .Fly2_End
 
 .Fly3:	spriteHeader
+	spritePiece	-$18, -$F, 3, 1, $1A, 0, 0, 0, 0
+	spritePiece	0, -$F, 2, 1, $1D, 0, 0, 0, 0
 	spritePiece	$C, 4, 1, 1, $30, 0, 0, 0, 0
 	spritePiece	-$18, -$C, 3, 2, 0, 0, 0, 0, 0
 	spritePiece	0, -$C, 3, 2, $F, 0, 0, 0, 0
 	spritePiece	-$18, 4, 3, 1, $15, 0, 0, 0, 0
 	spritePiece	0, 4, 2, 1, $18, 0, 0, 0, 0
-	spritePiece	-$14, -$F, 3, 1, $1A, 0, 0, 0, 0
-	spritePiece	4, -$F, 2, 1, $1D, 0, 0, 0, 0
 .Fly3_End
 
 .Fly4:	spriteHeader
+	spritePiece	-$18, -$C, 3, 1, $1F, 0, 0, 0, 0
+	spritePiece	0, -$C, 2, 1, $22, 0, 0, 0, 0
 	spritePiece	$C, 4, 2, 1, $31, 0, 0, 0, 0
 	spritePiece	-$18, -$C, 3, 2, 0, 0, 0, 0, 0
 	spritePiece	0, -$C, 3, 2, $F, 0, 0, 0, 0
 	spritePiece	-$18, 4, 3, 1, $15, 0, 0, 0, 0
 	spritePiece	0, 4, 2, 1, $18, 0, 0, 0, 0
-	spritePiece	-$14, -$C, 3, 1, $1F, 0, 0, 0, 0
-	spritePiece	4, -$C, 2, 1, $22, 0, 0, 0, 0
 .Fly4_End
 
-.Fire1:	spriteHeader
-	spritePiece	-$14, -$C, 4, 2, 0, 0, 0, 0, 0	; stopping and firing
+.Fire1:	spriteHeader	; stopping and firing
+	spritePiece	-$14, -$F, 3, 1, $1A, 0, 0, 0, 0
+	spritePiece	4, -$F, 2, 1, $1D, 0, 0, 0, 0
+	spritePiece	-$14, -$C, 4, 2, 0, 0, 0, 0, 0
 	spritePiece	-$14, 4, 4, 1, 8, 0, 0, 0, 0
 	spritePiece	$C, 4, 1, 1, $C, 0, 0, 0, 0
 	spritePiece	-$C, $C, 2, 1, $D, 0, 0, 0, 0
-	spritePiece	-$14, -$F, 3, 1, $1A, 0, 0, 0, 0
-	spritePiece	4, -$F, 2, 1, $1D, 0, 0, 0, 0
 .Fire1_End
 
 .Fire2:	spriteHeader
+	spritePiece	-$14, -$C, 3, 1, $1F, 0, 0, 0, 0
+	spritePiece	4, -$C, 2, 1, $22, 0, 0, 0, 0
 	spritePiece	-$14, -$C, 4, 2, 0, 0, 0, 0, 0
 	spritePiece	-$14, 4, 4, 1, 8, 0, 0, 0, 0
 	spritePiece	$C, 4, 1, 1, $C, 0, 0, 0, 0
 	spritePiece	-$C, $C, 2, 1, $D, 0, 0, 0, 0
 .Fire2_End
-	spritePiece	-$14, -$C, 3, 1, $1F, 0, 0, 0, 0
-	spritePiece	4, -$C, 2, 1, $22, 0, 0, 0, 0
 
 	even

--- a/s1fixed.flex.json
+++ b/s1fixed.flex.json
@@ -1,7 +1,7 @@
 {
     "Flex": 2,
     "name": "S1 Fixed",
-    "node": "d4d422f4-3f5e-413c-a9d5-8b5f0d2c6bda",
+    "node": "47929999-eaa2-49c3-847f-d4d422f43f5e",
     "objects": [
         {
             "name": "Common",
@@ -1144,7 +1144,7 @@
                 }
             ],
             "isDirectory": true,
-            "expanded": false,
+            "expanded": true,
             "uuid": "353e0542-f3ce-4bf7-bb7f-5d19313b45e5"
         },
         {


### PR DESCRIPTION
In the original game, Buzz Bomber's wing frames are misaligned and rendered behind the main body sprite. However, the downward flapping wing has a cut-out which lines up perfectly with the antennas, as well as a white pixel which again aligns perfectly with the highlight on the thorax.

This implies the wings were meant to render further left on the main flying sprites and over the abdomen when flapping downward to obey the 3/4 perspective of the sprites, whereas in the base game, this frame remains mostly obscured.

Additionally, the 2nd firing frame had an unused set of downward flapping wings, aligned correctly, at the end of that frame's data. It appears the header only listed 4 sprite pieces rather than 6, leaving those frames unused. I have restored those as well, with a draw order matching the corrected flying sprites for the sake of consistency.

Happy New Year!