### PR TITLE
Added a bug fix related to DAC fade-in

### DIFF
--- a/s1.sounddriver.asm
+++ b/s1.sounddriver.asm
@@ -1743,9 +1743,20 @@ DoFadeIn:
 ; ===========================================================================
 ; loc_726D6:
 .fadedone:
+	; Fixes a bug where pausing while a song is fading-in causes the DAC channel to remain muted 
 		bclr	#2,SMPS_RAM.v_music_dac_track.PlaybackControl(a6)	; Clear 'SFX overriding' bit
 		clr.b	SMPS_RAM.f_fadein_flag(a6)				; Stop fadein
+
+		tst.b	SMPS_RAM.v_music_dac_track.PlaybackControl(a6)		; is the DAC channel running?
+		bpl.s	.Resume_NoDAC						; if not, branch
+
+		moveq	#$FFFFFFB6,d0						; prepare FM channel 3/6 L/R/AMS/FMS address
+		move.b	SMPS_RAM.v_music_dac_track.AMSFMSPan(a6),d1		; load DAC channel's L/R/AMS/FMS value
+		jmp	WriteFMII(pc)						; write to FM 6
+
+.Resume_NoDAC:
 		rts	
+	; bugfix end
 ; End of function DoFadeIn
 
 ; ===========================================================================


### PR DESCRIPTION
Where this fix comes from and why it happens https://info.sonicretro.org/SCHG_How-to:Fix_Song_Restoration_Bugs_in_Sonic_1%27s_Sound_Driver#Fixing_the_DAC_fade-in_bug

Side note if you want to update the wording then go for it.