### PR TITLE
Correct the SEGA pitch in the stock driver branch

### DIFF
--- a/s1.sounddriver.asm
+++ b/s1.sounddriver.asm
@@ -804,24 +804,24 @@ PlaySegaSound:
 	; ValleyBell Panning Reset Fix
 		move.b	#$B6,d0						; Register: FM3/6 Panning
 		move.b	#$C0,d1						; Value: Enable both channels
-		jsr		WriteFMII(pc)				; Write to YM2612 Port 1 (for FM6) [sub_72764]
+		jsr	WriteFMII(pc)					; Write to YM2612 Port 1 (for FM6) [sub_72764]
 	; Fix end
 	; Puto Sega Sound Fix
-		lea		(SegaPCM).l,a2				; Load the SEGA PCM sample into a2. It's important that we use a2 since a0 and a1 are going to be used up ahead when reading the joypad ports 
-		move.l	#$6978,d3					; Load the size of the SEGA PCM sample into d3 
-		move.b	#$2A,(ym2612_a0).l			; $A04000 = $2A -> Write to DAC channel	  
+		lea	(SegaPCM).l,a2					; Load the SEGA PCM sample into a2. It's important that we use a2 since a0 and a1 are going to be used up ahead when reading the joypad ports 
+		move.l	#SegaPCM_End-SegaPCM,d3				; Load the size of the SEGA PCM sample into d3 
+		move.b	#$2A,(ym2612_a0).l				; $A04000 = $2A -> Write to DAC channel	  
 PlayPCM_Loop:	  
-		move.b	(a2)+,(ym2612_d0).l			; Write the PCM data (contained in a2) to $A04001 (YM2612 register D0) 
-		move.w	#$3,d0						; Write the pitch ($3 in this case) to d0 
-		dbf		d0,*						; Decrement d0; jump to itself if not 0. (for pitch control, avoids playing the sample too fast)  
-		sub.l	#1,d3						; Subtract 1 from the PCM sample size 
-		beq.s	return_PlayPCM				; If d3 = 0, we finished playing the PCM sample, so stop playing, leave this loop, and unfreeze the 68K 
-		lea		(v_jpadheld_actual).w,a0			; address where JoyPad states are written 
-		lea		(ym2612_d1).l,a1			; address where JoyPad states are read from 
-		jsr		(ReadJoypads).w				; Read only the first joypad port. It's important that we do NOT do the two ports, we don't have the cycles for that 
-		btst	#bitStart,(v_jpadheld_actual).w	; Check for Start button 
-		bne.s	return_PlayPCM				; If start is pressed, stop playing, leave this loop, and unfreeze the 68K 
-		bra.s	PlayPCM_Loop				; Otherwise, continue playing PCM sample
+		move.b	(a2)+,(ym2612_d0).l				; Write the PCM data (contained in a2) to $A04001 (YM2612 register D0) 
+		move.w	#$7,d0						; Write the pitch ($7 in this case) to d0 
+		dbf	d0,*						; Decrement d0; jump to itself if not 0. (for pitch control, avoids playing the sample too fast)  
+		subi.l	#1,d3						; Subtract 1 from the PCM sample size 
+		beq.s	return_PlayPCM					; If d3 = 0, we finished playing the PCM sample, so stop playing, leave this loop, and unfreeze the 68K 
+		lea	(v_jpadheld_actual).w,a0			; address where JoyPad states are written 
+		lea	(z80_port_1_data+1).l,a1			; address where JoyPad states are read from 
+		jsr	(ReadJoypads.read).w				; Read only the first joypad port. It's important that we do NOT do the two ports, we don't have the cycles for that 
+		btst	#bitStart,(v_jpadheld_actual).w			; Check for Start button 
+		bne.s	return_PlayPCM					; If start is pressed, stop playing, leave this loop, and unfreeze the 68K 
+		bra.s	PlayPCM_Loop					; Otherwise, continue playing PCM sample
 
 return_PlayPCM: 
 		addq.w	#4,sp 


### PR DESCRIPTION
Starting with https://github.com/RetroKoH/S1Fixed/commit/df3592a522633ff833c4f5eba4a9b424ec924f4a the sega chant's pitch is super slow due to ReadJoypads now taking longer/eating more CPU cycles, as such the "PlaySegaSound" command has been corrected, along with a few other small changes.