### PR TITLE
Move v_palmuscounter and v_spindashsfx1 to 3 into SMPS RAM

### DIFF
--- a/Variables.asm
+++ b/Variables.asm
@@ -220,7 +220,7 @@ v_pcyc_num:			ds.w	1		; palette cycling - current reference number
 v_pcyc_time:		ds.w	1		; palette cycling - time until the next change
 v_random:			ds.l	1		; pseudo random number buffer
 f_pause:			ds.b	1		; flag set to pause the game
-v_palmuscounter:	ds.b	1		; counter used to fix tempo for music in PAL regions
+				ds.b	1		; unused
 
 v_palette_frame:	ds.w	1
 v_palette_timer:	ds.b	1
@@ -471,15 +471,7 @@ v_oscillate:		ds.w	1		; oscillation bitfield
 v_timingandscreenvariables:
 v_timingvariables:	ds.b	$40		; values which oscillate - for swinging platforms, et al
 
-				ds.b	$1A		; unused
-
-	if SpinDashEnabled==1
-v_spindashsfx1:		ds.b	1
-v_spindashsfx2:		ds.b	1
-v_spindashsfx3:		ds.b	1
-	else
-				ds.b	3		; unused
-	endif
+				ds.b	$1D		; unused
 
 	if CameraDashLag
 v_cameralag:		ds.b	1		; camera lag after launching Spin Dash, Drop Dash, Flame Dash, or Drop Dash (1 byte)

--- a/s1.sounddriver.asm
+++ b/s1.sounddriver.asm
@@ -220,9 +220,9 @@ UpdateMusic:
 .nonewsound:
 	if SpinDashEnabled==1
 	; Spin Dash SFX
-		tst.b	(v_spindashsfx2).w
+		tst.b	SMPS_RAM.v_spindashsfx2(a6)
 		beq.s	.cont
-		subq.b	#1,(v_spindashsfx2).w
+		subq.b	#1,SMPS_RAM.v_spindashsfx2(a6)
 
 .cont:
 	; Spin Dash SFX end
@@ -295,9 +295,9 @@ DoStartZ80:
 		startZ80			; start the Z80
 		btst	#6,(v_megadrive).w	; is Mega Drive set to PAL region?
 		beq.s	.end			; if not, branch
-		subq.b	#1,(v_palmuscounter).w	; decrement PAL frame counter
+		subq.b	#1,SMPS_RAM.v_palmuscounter(a6)	; decrement PAL frame counter
 		bhi.s	.end			; is this the 6th frame? if not, branch
-		move.b	#6,(v_palmuscounter).w	; reset PAL frame counter
+		move.b	#6,SMPS_RAM.v_palmuscounter(a6)	; reset PAL frame counter
 		bra.w	UpdateMusic		; run sound driver a second time this frame
 
 	.end:
@@ -1049,12 +1049,12 @@ Sound_SpecialSFX:
 		tst.b	SMPS_RAM.f_fadein_flag(a6)
 		bne.w	Sound_ClearPriority
 	if SpinDashEnabled==1
-		clr.b	(v_spindashsfx1).w
+		clr.b	SMPS_RAM.v_spindashsfx1(a6)
 		cmp.b	#sfx_SpinDash,d7		; is this the Spin Dash sound?
 		bne.s	.cont3	; if not, branch
 		move.w	d0,-(sp)
-		move.b	(v_spindashsfx3).w,d0	; store extra frequency
-		tst.b	(v_spindashsfx2).w	; is the Spin Dash timer active?
+		move.b	SMPS_RAM.v_spindashsfx3(a6),d0	; store extra frequency
+		tst.b	SMPS_RAM.v_spindashsfx2(a6)	; is the Spin Dash timer active?
 		bne.s	.cont1		; if it is, branch
 		move.b	#-1,d0		; otherwise, reset frequency (becomes 0 on next line)
 
@@ -1062,11 +1062,11 @@ Sound_SpecialSFX:
 		addq.b	#1,d0
 		cmp.b	#$C,d0		; has the limit been reached?
 		bcc.s	.cont2		; if it has, branch
-		move.b	d0,(v_spindashsfx3).w	; otherwise, set new frequency
+		move.b	d0,SMPS_RAM.v_spindashsfx3(a6)	; otherwise, set new frequency
 
 .cont2:
-		move.b	#1,(v_spindashsfx1).w	; set flag
-		move.b	#60,(v_spindashsfx2).w	; set timer
+		move.b	#1,SMPS_RAM.v_spindashsfx1(a6)	; set flag
+		move.b	#60,SMPS_RAM.v_spindashsfx2(a6)	; set timer
 		move.w	(sp)+,d0
 
 .cont3:
@@ -1086,7 +1086,7 @@ Sound_PlaySFX:
 		tst.b	SMPS_RAM.f_fadein_flag(a6)		; Is music being faded in?
 		bne.w	Sound_ClearPriority		; Exit if it is
 	if SpinDashEnabled==1
-		clr.b	(v_spindashsfx1).w		; Spin Dash SFX
+		clr.b	SMPS_RAM.v_spindashsfx1(a6)	; Spin Dash SFX
 	endif
 		cmpi.b	#sfx_Ring,d7			; is ring sound	effect played?
 		bne.s	.sfx_notRing			; if not, branch
@@ -1110,8 +1110,8 @@ Sound_PlaySFX:
 		cmp.b	#sfx_SpinDash,d7		; is this the Spin Dash sound?
 		bne.s	.cont3					; if not, branch
 		move.w	d0,-(sp)
-		move.b	(v_spindashsfx3).w,d0	; store extra frequency
-		tst.b	(v_spindashsfx2).w		; is the Spin Dash timer active?
+		move.b	SMPS_RAM.v_spindashsfx3(a6),d0		; store extra frequency
+		tst.b	SMPS_RAM.v_spindashsfx2(a6)		; is the Spin Dash timer active?
 		bne.s	.cont1					; if it is, branch
 		move.b	#-1,d0					; otherwise, reset frequency (becomes 0 on next line)
 
@@ -1119,11 +1119,11 @@ Sound_PlaySFX:
 		addq.b	#1,d0
 		cmp.b	#$C,d0					; has the limit been reached?
 		bcc.s	.cont2					; if it has, branch
-		move.b	d0,(v_spindashsfx3).w	; otherwise, set new frequency
+		move.b	d0,SMPS_RAM.v_spindashsfx3(a6)		; otherwise, set new frequency
 
 .cont2:
-		move.b	#1,(v_spindashsfx1).w	; set flag
-		move.b	#60,(v_spindashsfx2).w	; set timer
+		move.b	#1,SMPS_RAM.v_spindashsfx1(a6)	; set flag
+		move.b	#60,SMPS_RAM.v_spindashsfx2(a6)	; set timer
 		move.w	(sp)+,d0
 
 .cont3:
@@ -1190,10 +1190,10 @@ SoundEffects_Common:
 		move.w	(a1)+,SMPS_Track.Transpose(a5)	; load FM/PSG channel modifier
 	if SpinDashEnabled==1
 	; Spin Dash SFX
-		tst.b	(v_spindashsfx1).w	; is the Spin Dash sound playing?
+		tst.b	SMPS_RAM.v_spindashsfx1(a6)	; is the Spin Dash sound playing?
 		beq.s	.cont		; if not, branch
 		move.w	d0,-(sp)
-		move.b	(v_spindashsfx3).w,d0
+		move.b	SMPS_RAM.v_spindashsfx3(a6),d0
 		add.b	d0,8(a5)
 		move.w	(sp)+,d0
 

--- a/s1.sounddriver.ram.asm
+++ b/s1.sounddriver.ram.asm
@@ -62,7 +62,16 @@ v_speeduptempo:			ds.b	1	; music - tempo modifier with speed shoes
 f_speedup:				ds.b	1	; flag indicating whether speed shoes tempo is on ($80) or off ($00)
 v_ring_speaker:			ds.b	1	; which speaker the "ring" sound is played in (00 = right; 01 = left)
 f_push_playing:			ds.b	1	; if set, prevents further push sounds from playing
-					ds.b	$13	; unused
+v_palmuscounter:		ds.b	1	; counter used to fix tempo for music in PAL regions
+
+	if SpinDashEnabled==1
+v_spindashsfx1:			ds.b	1
+v_spindashsfx2:			ds.b	1
+v_spindashsfx3:			ds.b	1
+				ds.b	$F	; unused
+	else
+				ds.b	$12	; unused
+	endif				
 
 v_track_ram:
 v_music_track_ram:			; Start of music RAM


### PR DESCRIPTION
this is more of a "doesn't change much but makes more sense logically" PR, these variables are sound driver based, so makes sense logically for them to be paired up with the other sound driver ram variables, due to this change we can also use a6 for these "see the sound driver for what i mean"